### PR TITLE
fix: add support for node 22.18.0

### DIFF
--- a/src/fs/stat-fast.js
+++ b/src/fs/stat-fast.js
@@ -1,6 +1,6 @@
 import { Stats } from "../safe/fs.js"
 import safeProcess from "../safe/process.js"
-import { gte, lt  } from "semver"
+import { gte, lt } from "semver"
 
 import binding from "../binding.js"
 import shared from "../shared.js"
@@ -11,7 +11,7 @@ function init() {
   const { isFile } = Stats.prototype
 
   let useFastPath
-  let twoArgsInternalModuleStat = gte(safeProcess.versions.node, "22.10.0") && lt(safeProcess.versions.node, "24.0.0")
+  let twoArgsInternalModuleStat = gte(safeProcess.versions.node, "22.10.0") && lt(safeProcess.versions.node, "22.18.0")
 
   function statFast(thePath) {
     if (typeof thePath !== "string") {


### PR DESCRIPTION
Fixes #8 

Fix similar to https://github.com/httptoolkit/esm/commit/936e14b8dad36cc1c0dc1c805bdfa9afb8f6defd

Node 22.18.0 requires 1 argument for internalModuleStat again

```
  #  node (vitest)[96703]: void node::fs::InternalModuleStat(const FunctionCallbackInfo<Value> &) at ../src/node_file.cc:1052
  #  Assertion failed: (args.Length()) == (1)

----- Native stack trace -----

 1: 0x10c558796 node::Assert(node::AssertionInfo const&) [$HOME/.nvm/versions/node/v22.18.0/bin/node]
 2: 0x10e5f6170 node::fs::InternalModuleStat(v8::FunctionCallbackInfo<v8::Value> const&) (.cold.3) [$HOME/.nvm/versions/node/v22.18.0/bin/node]
 3: 0x10c56c477 node::fs::InternalModuleStat(v8::FunctionCallbackInfo<v8::Value> const&) [$HOME/.nvm/versions/node/v22.18.0/bin/node]
 4: 0x10d25e4e2 Builtins_CallApiCallbackGeneric [$HOME/.nvm/versions/node/v22.18.0/bin/node]
 5: 0x10d25c79e Builtins_InterpreterEntryTrampoline [$HOME/.nvm/versions/node/v22.18.0/bin/node]

----- JavaScript stack trace -----

1: ./node_modules/@httptoolkit/esm/esm.js:1:39956
2: ./node_modules/@httptoolkit/esm/esm.js:1:39597
3: ./node_modules/@httptoolkit/esm/esm.js:1:39927
4: ./node_modules/@httptoolkit/esm/esm.js:1:202740
5: ./node_modules/@httptoolkit/esm/esm.js:1:202824
6: ./node_modules/@httptoolkit/esm/esm.js:1:202925
7: ./node_modules/@httptoolkit/esm/esm.js:1:287315
8: ./node_modules/@httptoolkit/esm/esm.js:1:289897
9: e (./node_modules/@httptoolkit/esm/esm.js:1:291028)
10: get (./node_modules/@httptoolkit/esm/esm.js:1:291095)


Abort trap: 6
```